### PR TITLE
Add cite-group-delimiter attribute, discuss cite grouping and be more spe

### DIFF
--- a/specification.txt
+++ b/specification.txt
@@ -1487,39 +1487,71 @@ For cites that could not be disambiguated by steps 1-4, a final attempt at
 disambiguation is performed by rendering the cite with the ``disambiguate``
 condition testing "true" [Step (5)] (see `Choose`_).
 
+Citation Grouping
+'''''''''''''''''
+
+Cites in "author-date" styles (see ``cs:category`` in `Info`_) that start with
+the output of a ``cs:names`` element, followed by a year or "no date" term, and
+(optionally) end with other rendering elements (e.g. a "locator" or explicit
+"year-suffix" variable), are subject to cite grouping. Cite grouping is only
+active when ``cs:citation`` carries the ``collapse`` or ``cite-group-delimiter``
+attributes (see `Citation Collapsing`_).
+
+After cite sorting and disambiguation, any of such cites that share the same
+output of the ``cs:names`` element (this includes any output rendered through
+``cs:substitute``) are grouped together into a cite group. Cites are grouped
+with the first cite of the group while maintaining their original order relative
+to the other cites in the group. E.g. the citation "(Doe 2002, Smith 2004, Doe
+1999)" becomes "(Doe 2002, Doe 1999, Smith 2004)", where the two references by
+Doe form a cite group.
+
 Citation Collapsing
 '''''''''''''''''''
+
+Cite groups in citations of "author-date" styles, and cite ranges in citations
+in "numeric" styles can be collapsed through the use of the ``collapse``
+attribute.
 
 ``collapse``
     Activates citation collapsing. Allowed values:
     
-    -  "citation-number" - collapses numeric citation ranges (e.g. from "[1, 2,
-       3, 5]" to "[1-3, 5]"). Only increasing ranges are collapsed, e.g. "[3, 2,
-       1]" will not collapse (to see how to sort cites by their
-       ``citation-number`` variable, see `Sorting`_).
-    -  "year" - when consecutive cites share the same names in the rendered name
-       variables, subsequent cites are collapsed to only a year, e.g. from "(Doe
-       2000, Doe 2001)" to "(Doe 2000, 2001)".
-    -  "year-suffix" - collapses as "year", but also collapses repeating years
-       to only the year-suffix, e.g. "(Doe 2000a, b)" instead of "(Doe 2000a,
+    -  "citation-number" - collapses ranges of cite numbers (rendered through
+       the "citation-number" variable) in citations for "numeric" styles (e.g.
+       from "[1, 2, 3, 5]" to "[1-3, 5]"). Only increasing ranges collapse, e.g.
+       "[3, 2, 1]" will not collapse (to see how to sort cites by
+       "citation-number", see `Sorting`_).
+    -  "year" - collapses cite groups by suppressing the output of the
+       ``cs:names`` element for subsequent cites in the group, e.g. "(Doe 2000,
+       Doe 2001)" becomes "(Doe 2000, 2001)".
+    -  "year-suffix" - collapses as "year", but also suppresses repeating years
+       within the cite group, e.g. "(Doe 2000a, b)" instead of "(Doe 2000a,
        2000b)".
     -  "year-suffix-ranged" - collapses as "year-suffix", but also collapses
-       ranges of year-suffix markers, e.g. "(Doe 2000a-c,e)" instead of "(Doe
-       2000a, b, c, e)".
+       ranges of year-suffixes, e.g. "(Doe 2000a-c,e)" instead of "(Doe 2000a,
+       b, c, e)".
+    
+    "year-suffix" and "year-suffix-ranged" fall back to "year" for cites with
+    any output after the year or "no date" term, such as a locator. E.g. "(Doe
+    2000a-c, 2000d, p. 5, 2000e,f)" (in this citation, the cite for "Doe 2000d"
+    has a locator, preventing the cite from further collapsing).
+
+``cite-group-delimiter``
+    Specifies the delimiter for cites within a cite group. Defaults to the
+    delimiter set on ``cs:layout`` in ``cs:citation``.
 
 ``year-suffix-delimiter``
-    Specifies the delimiter for year-suffix elements (defaults to the delimiter
-    set on ``cs:layout`` in ``cs:citation``). E.g. with ``collapse`` set to
-    "year-suffix", the ``delimiter`` on ``cs:layout`` in ``cs:citation`` set to
-    "; ", and the ``year-suffix-delimiter`` set to ",", citations look like
-    "(Smith 1999a,b; 2000; Jones 2001)".
+    Specifies the delimiter for year-suffixes. Defaults to the delimiter set on
+    ``cs:layout`` in ``cs:citation``.
 
 ``after-collapse-delimiter``
-    Specifies the cite delimiter to be used *after* a group of collapsed cites.
-    E.g. with ``collapse`` set to "year-suffix", the ``delimiter`` on
-    ``cs:layout`` in ``cs:citation`` set to ", ", and
-    ``after-collapse-delimiter`` set to "; ", citations look like "(Smith 1999a,
-    b, 2000; Jones 2001, Brown 2007)".
+    Specifies the cite delimiter to be used *after* a collapsed cite group.
+    Defaults to the delimiter set on ``cs:layout`` in ``cs:citation``.
+
+An illustration of the use of these delimiters: with ``collapse`` set to
+"year-suffix", ``delimiter`` on ``cs:layout`` in ``cs:citation`` set to ", ",
+``cite-group-delimiter`` set to ",", ``year-suffix-delimiter`` set to "/", and
+``after-collapse-delimiter`` set to "; ", citations look like "(Smith
+1999a/b,2000; Jones 2001, Brown 2007)".
 
 Note Distance
 '''''''''''''


### PR DESCRIPTION
Add "cite-group-delimiter" attribute, discuss cite grouping and be more specific about cite collapsing.

This is linked to #12, https://github.com/citation-style-language/schema/issues/40 and https://github.com/citation-style-language/schema/issues/52
