### PR TITLE
Clearing up documentation on cs:link for dependent styles

### DIFF
--- a/specification.txt
+++ b/specification.txt
@@ -273,11 +273,6 @@ locale code <http://books.xmlschemata.org/relaxng/ch19-77191.html>`_). For
 ``cs:link``, the attribute can also be used to indicate the language of the link
 target.
 
-In `dependent styles`_, ``cs:link`` must be used with ``rel`` set to
-"independent-parent", with the URI of the independent parent style set on
-``href``. In addition, ``cs:link`` should not be used with ``rel`` set to
-"template".
-
 An example of ``cs:info`` for an independent style:
 
 .. sourcecode:: xml
@@ -286,6 +281,44 @@ An example of ``cs:info`` for an independent style:
       <title>Style Title</title>
       <id>http://www.zotero.org/styles/style-title</id>
       <link href="http://www.zotero.org/styles/style-title" rel="self"/>
+      <author>
+        <name>Author Name</name>
+        <email>name@domain.com</email>
+        <uri>http://www.domain.com/name</uri>
+      </author>
+      <category citation-format="author-date"/>
+      <category field="zoology"/>
+      <updated>2008-10-29T21:01:24+00:00</updated>
+      <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work
+      is licensed under a Creative Commons Attribution-Share Alike 3.0 Unported
+      License</rights>
+    </info>
+
+In `dependent styles`_, the child elements of ``cs:info`` are the same as for
+independent styles except for the ``cs:link`` element, which is now compulsory.
+It must be used with ``rel`` set to "independent-parent", with the URI of the
+independent parent style set on ``href``:
+
+``cs:link``
+    Must be used with ``rel`` set to "independent-parent", may be used for
+    documentation. ``cs:link`` must carry two attributes: ``href``, set to
+    a URI (usually a URL), and ``rel``, whose value indicates how the URI
+    relates to the style. The possible values of ``rel``:
+    
+    -  "independent-parent" - style URI for independent parent
+    -  "documentation" - URI of style documentation (optional)
+    
+    The ``cs:link`` element may contain content describing the link.
+
+An example of ``cs:info`` for a dependent style:
+
+.. sourcecode:: xml
+
+    <info>
+      <title>Dependent Style Title</title>
+      <id>http://www.zotero.org/styles/dependent-style-title</id>
+      <link href="http://www.zotero.org/styles/style-title" rel="independent-parent"/>
+      <link href="http://www.journal.org/dependent-style/documentation" rel="documentation"/>
       <author>
         <name>Author Name</name>
         <email>name@domain.com</email>


### PR DESCRIPTION
Clearing up documentation on cs:link for dependent styles to say that rel="independent-parent" must be provided, and rel="self" and rel="template" must not.
