### PR TITLE
Correct order of disambiguation methods

### DIFF
--- a/specification.txt
+++ b/specification.txt
@@ -1549,20 +1549,22 @@ Citation-specific Options
 Disambiguation
 ''''''''''''''
 
-A cite is ambiguous when it matches multiple bibliographic entries [#]_. There
-are four methods available to eliminate such ambiguity:
+A cite is ambiguous when it matches multiple bibliographic entries [#]_. Four
+methods are available to eliminate such ambiguity, which are always tried in the
+following order:
 
 1. Show more names
 2. Expand names (adding initials or full given names)
-3. Add a year-suffix
-4. Render the cite with the ``disambiguate`` attribute of ``cs:choose``
+3. Render the cite with the ``disambiguate`` attribute of ``cs:choose``
    conditions testing "true"
+4. Add a year-suffix
 
-Method 2 can also be used for global *name disambiguation*, covering all cites,
-ambiguous and unambiguous, throughout the document.
+Method 2 can also be used for the separate purpose of global *name
+disambiguation*, covering both ambiguous and unambiguous cites throughout the
+document.
 
-Disambiguation methods are activated with the following optional attributes, and
-are always tried in the listed order:
+The four disambiguation methods can be individually activated with the following
+optional attributes:
 
 ``disambiguate-add-names`` [Step (1)]
     If set to "true" ("false" is the default), names that would otherwise be
@@ -1646,23 +1648,23 @@ are always tried in the listed order:
             affected, and disambiguation stops after the first name that
             eliminates cite ambiguity.
 
-``disambiguate-add-year-suffix`` [Step (3)]
+A disambiguation attempt can also be made by rendering ambiguous cites with the
+``disambiguate`` condition testing "true" [Step (3)] (see `Choose`_).
+
+``disambiguate-add-year-suffix`` [Step (4)]
     If set to "true" ("false" is the default), an alphabetic year-suffix is
     added to ambiguous cites (e.g. "Doe 2007, Doe 2007" becomes "Doe 2007a, Doe
-    2007b") and to their corresponding bibliographic entries. The assignment of
-    the year-suffixes follows the order of the bibliographies entries, and
-    additional letters are used once "z" is reached ("z", "aa", "ab", ..., "az",
-    "ba", etc.). By default the year-suffix is appended to the cite, and to the
-    first year rendered through ``cs:date`` in the bibliographic entry, but its
-    location can be controlled by explicitly rendering the "year-suffix"
-    variable using ``cs:text``. If "year-suffix" is rendered through ``cs:text``
-    in the scope of ``cs:citation``, it is suppressed for ``cs:bibliography``,
-    unless it is also rendered through ``cs:text`` in the scope of
-    ``cs:bibliography``, and vice versa.
-
-If ambiguous cites remain after applying the selected disambiguation methods
-described above, a final disambiguation attempt is made by rendering these cites
-with the ``disambiguate`` condition testing "true" [Step (4)] (see `Choose`_).
+    2007b") and to their corresponding bibliographic entries. This
+    disambiguation method is always successful. The assignment of year-suffixes
+    follows the order of the bibliographies entries, and additional letters are
+    used once "z" is reached ("z", "aa", "ab", ..., "az", "ba", etc.). By
+    default the year-suffix is appended to the cite, and to the first year
+    rendered through ``cs:date`` in the bibliographic entry, but its location
+    can be controlled by explicitly rendering the "year-suffix" variable using
+    ``cs:text``. If "year-suffix" is rendered through ``cs:text`` in the scope
+    of ``cs:citation``, it is suppressed for ``cs:bibliography``, unless it is
+    also rendered through ``cs:text`` in the scope of ``cs:bibliography``, and
+    vice versa.
 
 .. [#] The presence of uncited entries in the bibliography can make cites in the
        document ambiguous. To make sure such cites are disambiguated, the CSL

--- a/specification.txt
+++ b/specification.txt
@@ -1566,15 +1566,13 @@ document.
 The four disambiguation methods can be individually activated with the following
 optional attributes:
 
-``disambiguate-add-names`` [Step (1)]
+``disambiguate-add-names`` [Method (1)]
     If set to "true" ("false" is the default), names that would otherwise be
     hidden as a result of et-al abbreviation are added one by one to all members
     of a set of ambiguous cites, until no more cites in the set can be
-    disambiguated by adding names. If necessary to render the disambiguating
-    names in the bibliography, et-al abbreviation in the corresponding
-    bibliographic entries is similarly relaxed for the affected name variables.
+    disambiguated by adding names.
 
-``disambiguate-add-givenname`` [Step (2)]
+``disambiguate-add-givenname`` [Method (2)]
     If set to "true" ("false" is the default), ambiguous names (names that are
     identical in their "short" or initialized "long" form, but differ when
     initials are added or the full given name is shown) are expanded. Name
@@ -1593,10 +1591,7 @@ optional attributes:
     hidden as a result of et-al abbreviation after the disambiguation attempt of
     ``disambiguate-add-names`` are added one by one to all members of a set of
     ambiguous cites, until no more cites in the set can be disambiguated by
-    adding expanded names. If necessary to render the disambiguating expanded
-    names in the bibliography, the affected name variables in the corresponding
-    bibliographic entries are similarly subjected to name expansion and
-    relaxation of et-al abbreviation.
+    adding expanded names.
 
 ``givenname-disambiguation-rule``
     Specifies a) whether the purpose of name expansion is limited to
@@ -1653,10 +1648,21 @@ optional attributes:
             affected, and disambiguation stops after the first name that
             eliminates cite ambiguity.
 
-A disambiguation attempt can also be made by rendering ambiguous cites with the
-``disambiguate`` condition testing "true" [Step (3)] (see `Choose`_).
+In the description of disambiguation methods (1) and (2) above, we assumed that
+each (disambiguated) cite has an unambiguous link to its bibliographic entry. To
+assure that each cite does in fact uniquely identify its entry in the
+bibliography, detail that distinguishes cites (such as names, initials, and full
+given names) must be shown in the corresponding bibliography entries. If this is
+not the case, disambiguation methods (1) and (2) also act on all members of a
+set of ambiguously cited bibliographic entries, until no more entries in the set
+can be unambiguously cited by adding (expanded) names. Each method only takes
+effect on the involved bibliographic entries after it has been used to
+disambiguate cites.
 
-``disambiguate-add-year-suffix`` [Step (4)]
+A disambiguation attempt can also be made by rendering ambiguous cites with the
+``disambiguate`` condition testing "true" [Method (3)] (see `Choose`_).
+
+``disambiguate-add-year-suffix`` [Method (4)]
     If set to "true" ("false" is the default), an alphabetic year-suffix is
     added to ambiguous cites (e.g. "Doe 2007, Doe 2007" becomes "Doe 2007a, Doe
     2007b") and to their corresponding bibliographic entries. This final

--- a/specification.txt
+++ b/specification.txt
@@ -1570,7 +1570,9 @@ optional attributes:
     If set to "true" ("false" is the default), names that would otherwise be
     hidden as a result of et-al abbreviation are added one by one to all members
     of a set of ambiguous cites, until no more cites in the set can be
-    disambiguated by adding names.
+    disambiguated by adding names. If necessary to render the disambiguating
+    names in the bibliography, et-al abbreviation in the corresponding
+    bibliographic entries is similarly relaxed for the affected name variables.
 
 ``disambiguate-add-givenname`` [Step (2)]
     If set to "true" ("false" is the default), ambiguous names (names that are
@@ -1591,7 +1593,10 @@ optional attributes:
     hidden as a result of et-al abbreviation after the disambiguation attempt of
     ``disambiguate-add-names`` are added one by one to all members of a set of
     ambiguous cites, until no more cites in the set can be disambiguated by
-    adding expanded names.
+    adding expanded names. If necessary to render the disambiguating expanded
+    names in the bibliography, the affected name variables in the corresponding
+    bibliographic entries are similarly subjected to name expansion and
+    relaxation of et-al abbreviation.
 
 ``givenname-disambiguation-rule``
     Specifies a) whether the purpose of name expansion is limited to
@@ -1654,7 +1659,7 @@ A disambiguation attempt can also be made by rendering ambiguous cites with the
 ``disambiguate-add-year-suffix`` [Step (4)]
     If set to "true" ("false" is the default), an alphabetic year-suffix is
     added to ambiguous cites (e.g. "Doe 2007, Doe 2007" becomes "Doe 2007a, Doe
-    2007b") and to their corresponding bibliographic entries. This
+    2007b") and to their corresponding bibliographic entries. This final
     disambiguation method is always successful. The assignment of year-suffixes
     follows the order of the bibliographies entries, and additional letters are
     used once "z" is reached ("z", "aa", "ab", ..., "az", "ba", etc.). By
@@ -1666,10 +1671,10 @@ A disambiguation attempt can also be made by rendering ambiguous cites with the
     also rendered through ``cs:text`` in the scope of ``cs:bibliography``, and
     vice versa.
 
-.. [#] The presence of uncited entries in the bibliography can make cites in the
+.. [#] Including uncited entries in the bibliography can make cites in the
        document ambiguous. To make sure such cites are disambiguated, the CSL
-       processor should create hidden "ghost" cites for all uncited
-       bibliographic entries and include them in the disambiguation process.
+       processor should include (invisible) cites for such uncited bibliographic
+       entries in the disambiguation process.
 
 Cite Grouping
 '''''''''''''


### PR DESCRIPTION
In response to https://github.com/citation-style-language/documentation/issues/25 and https://bitbucket.org/bdarcus/citeproc-test/issue/10/disambiguate_bycitedisambiguateconditiontx .

I'll accept this pull request once people have had a chance to review.
