### PR TITLE
Mention cs:label elements in cs:group description

### DIFF
--- a/specification.txt
+++ b/specification.txt
@@ -1370,7 +1370,7 @@ elements`_ (with the exception of ``cs:layout``). ``cs:group`` may carry the
 implicitly acts as a conditional: ``cs:group`` and its child elements are
 suppressed if a) at least one rendering element in ``cs:group`` calls a variable
 (either directly or via a macro), and b) all variables that are called are
-empty. This accommodates descriptive ``cs:text`` elements. For example,
+empty. This accommodates descriptive ``cs:text`` and ``cs:label``elements. For example,
 
 .. sourcecode:: xml
 


### PR DESCRIPTION
Just noticed that cs:label element is not mentioned in the description of cs:group implicit conditional behaviour.
