### PR TITLE
fix for ambiguous code example for <et-al>

### DIFF
--- a/specification.rst
+++ b/specification.rst
@@ -1277,7 +1277,15 @@ term:
 .. sourcecode:: xml
 
     <names variable="author">
-      <et-al term="and others" font-style="italic"/>
+      <et-al font-style="italic"/>
+    </names>
+
+Or it can be used to select another term:
+
+.. sourcecode:: xml
+
+    <names variable="author">
+      <et-al term="and others"/>
     </names>
 
 Substitute


### PR DESCRIPTION
I think the documentation for [`<et-al>`](https://docs.citationstyles.org/en/master/specification.html#et-al) is potentially confusing:

<img width="722" alt="Screen Shot 2019-05-20 at 06 47 36" src="https://user-images.githubusercontent.com/681975/57998929-6dc3a980-7acb-11e9-86bf-dabfb7a99304.png">

In the screenshot above, the doc talks about italicising the `et-al` term but select another term in the example.

@rmzelle @adam3smith 