### PR TITLE
Add section on whitespace handling

### DIFF
--- a/specification.rst
+++ b/specification.rst
@@ -52,7 +52,19 @@ Whitespace Handling
 
 CSL styles are valid XML, but CSL processors MUST NOT normalize attribute values 
 by trimming leading or trailing whitespace from attributes which define text that 
-is intended for output: delimiter="," and delimiter=" ," are distinct values."
+is intended for output:
+
+- after-collapse-delimiter
+- cite-group-delimiter
+- delimiter
+- initialize-with
+- name-delimiter
+- names-delimiter
+- prefix
+- range-delimiter
+- sort-separator
+- suffix
+- year-suffix-delimiter
 
 File Types
 ----------

--- a/specification.rst
+++ b/specification.rst
@@ -47,6 +47,13 @@ throughout this specification when referring to CSL elements, but is generally
 omitted in favor of a default namespace declaration (set with
 the ``xmlns`` attribute) on the root ``cs:style`` or ``cs:locale`` element.
 
+Whitespace Handling
+-------------------
+
+CSL styles are valid XML, but CSL processors MUST NOT normalize attribute values 
+by trimming leading or trailing whitespace from attributes which define text that 
+is intended for output: delimiter="," and delimiter=" ," are distinct values."
+
 File Types
 ----------
 

--- a/specification.rst
+++ b/specification.rst
@@ -65,6 +65,7 @@ is intended for output:
 - sort-separator
 - suffix
 - year-suffix-delimiter
+-value
 
 File Types
 ----------


### PR DESCRIPTION
CSL's expectations on whitespace handling of attribute values differs 
from the XML specification. This explains.

Closes citation-style-language/schema#270