### PR TITLE
Clarify meaningfulness of name-label ordering

### DIFF
--- a/specification.rst
+++ b/specification.rst
@@ -1339,12 +1339,14 @@ substituted by the "editor" name variable, or, when no editors exist, by the
 Label in ``cs:names``
 ^^^^^^^^^^^^^^^^^^^^^
 
-The optional ``cs:label`` element (see `label`_) must be included after the
-``cs:name`` and ``cs:et-al`` elements, but before the ``cs:substitute`` element.
-When used as a child element of ``cs:names``, ``cs:label`` does not carry the
-``variable`` attribute; it uses the variable(s) set on the parent ``cs:names``
-element instead. A second difference is that the ``form`` attribute may also be
-set to "verb" or "verb-short", so that the allowed values are:
+A ``cs:label`` element (see `label`_) may optionally be included in 
+``cs:names``. It must appear before the ``cs:substitute`` element. The position 
+of ``cs:label`` relative to ``cs:name`` determines the order of the name and 
+label in the rendered text. When used as a child element of ``cs:names``, 
+``cs:label`` does not carry the ``variable`` attribute; it uses the variable(s) 
+set on the parent ``cs:names`` element instead. A second difference is that the 
+``form`` attribute may also be set to "verb" or "verb-short", so that the 
+allowed values are:
 
 -  "long" - (default), e.g. "editor" and "editors" for the "editor" term
 -  "short" - e.g. "ed." and "eds." for the term "editor"


### PR DESCRIPTION
See https://discourse.citationstyles.org/t/names-label-position/1216/3 and https://github.com/citation-style-language/csl-evolution/issues/9

I considered whether to make this change or instead clearly specify that order **does not** matter and that the relative positioning should be determined by the form used:
- `long` and `short` should always come after the `name`
- `verb` and `verb-short` should always come before the `name`

I opted for this solution for three reasons:
  1. At least citeproc-js and pandoc-citeproc already implement the current order-matters behavior
  1. There is no obvious position for `symbol`. `names` would generally not have this form, but it might be used in a user hack in a custom style to create an alternative label for a variable. Forcing either position would constrain those uses.
  1. Some styles exist relying on this behavior. For example, the default CSL en-US localization for `editor form="verb-short"` is `"ed. by"`. If a style instead wanted a citation to appear like this—_Book title_. (ed. John Doe)—they would have written the style to use `form="short"` and placed `label` before `name`. Making order not matter would break that style and require it to be revised to re-define the `editor form="short"` term.

Closes https://github.com/citation-style-language/documentation/issues/45