### PR TITLE
Define delimiter-encapsulation

### DIFF
--- a/specification.rst
+++ b/specification.rst
@@ -1547,7 +1547,7 @@ control the testing logic, with allowed values:
    for any given test value
 
 The output of ``cs:choose`` (i.e. the output of the matching ``cs:if``, 
-``cs:else-if``, or ``cs:else``) is _not_ delimiter-encapsulated (see 
+``cs:else-if``, or ``cs:else``) is *not* delimiter-encapsulated (see 
 `delimiter`_): if there are multiple elements output by the chosen branch, when 
 rendering a `delimiter`_ set on the nearest parent delimiting element, they are 
 considered to be separate pieces of output and delimiters are placed between 

--- a/specification.rst
+++ b/specification.rst
@@ -2243,8 +2243,7 @@ allowed when ``cs:date`` calls a localized date format), ``cs:names``
 (delimiting names within name lists), ``cs:group`` and ``cs:layout`` (delimiting
 the output of the child elements).
 
-A delimiting element is any element as above which takes a ``delimiter`` 
-attribute, whether the attribute is supplied or not.
+A delimiting element is any element as above which takes a ``delimiter`` attribute, whether the attribute is supplied or not.
 
 Delimiters from any ancestor delimiting element are not applied within the output of a delimiting element. The following produces ``retrieved: <http://example.com>``:
 

--- a/specification.rst
+++ b/specification.rst
@@ -384,7 +384,7 @@ the item type is "book":
       </citation>
     </style>
 
-The output of a ``<text macro="...">`` does not have delimiters from a parent 
+The output of a ``<text macro="...">`` does not have delimiters from a parent
 delimiting element interspersed within it (see `delimiter`_).
 
 Locale
@@ -1546,8 +1546,8 @@ control the testing logic, with allowed values:
 -  "none" - element only tests "true" when none of the conditions test "true"
    for any given test value
 
-The output of ``cs:choose`` (i.e. the output of the matching ``cs:if``, 
-``cs:else-if``, or ``cs:else``) *does* have delimiters from a parent delimiting 
+The output of ``cs:choose`` (i.e. the output of the matching ``cs:if``,
+``cs:else-if``, or ``cs:else``) *does* have delimiters from a parent delimiting
 element interspersed within it (see `delimiter`_).
 
 Style Behavior
@@ -2249,10 +2249,9 @@ the output of the child elements).
 A delimiting element is any element as above which takes a ``delimiter`` 
 attribute, whether the attribute is supplied or not.
 
-The output of all delimiting elements is not subject to surrounding delimiters: 
-no ``delimiter`` from a parent delimiting element will delimit between multiple 
-outputs of an inner delimiting element. The following produces
-``retrieved: <http://example.com>``:
+The output of a delimiting element does not have delimiters from a parent
+delimiting element interspersed within it. The following produces ``retrieved:
+<http://example.com>``:
 
 .. sourcecode:: xml
 
@@ -2260,7 +2259,7 @@ outputs of an inner delimiting element. The following produces
       <text term="retrieved" />
       <group>
         <text value="&lt;" />
-        <text variable="URL"/>
+        <text variable="URL" />
         <text value="&gt;" />
       </group>
     </group>

--- a/specification.rst
+++ b/specification.rst
@@ -384,8 +384,7 @@ the item type is "book":
       </citation>
     </style>
 
-The output of a ``<text macro="...">`` does not have delimiters from any
-ancestor delimiting element interspersed within it (see `delimiter`_).
+Delimiters from any ancestor delimiting element are not applied within the output of a ``<text macro="...">`` element (see `delimiter`_).
 
 Locale
 ^^^^^^

--- a/specification.rst
+++ b/specification.rst
@@ -384,8 +384,8 @@ the item type is "book":
       </citation>
     </style>
 
-The output of a ``<text macro="...">`` does not have delimiters from a parent
-delimiting element interspersed within it (see `delimiter`_).
+The output of a ``<text macro="...">`` does not have delimiters from any
+ancestor delimiting element interspersed within it (see `delimiter`_).
 
 Locale
 ^^^^^^
@@ -1547,8 +1547,8 @@ control the testing logic, with allowed values:
    for any given test value
 
 The output of ``cs:choose`` (i.e. the output of the matching ``cs:if``,
-``cs:else-if``, or ``cs:else``) *does* have delimiters from a parent delimiting
-element interspersed within it (see `delimiter`_).
+``cs:else-if``, or ``cs:else``) *does* have delimiters from the nearest
+ancestor delimiting element interspersed within it (see `delimiter`_).
 
 Style Behavior
 --------------
@@ -2249,7 +2249,7 @@ the output of the child elements).
 A delimiting element is any element as above which takes a ``delimiter`` 
 attribute, whether the attribute is supplied or not.
 
-The output of a delimiting element does not have delimiters from a parent
+The output of a delimiting element does not have delimiters from any ancestor
 delimiting element interspersed within it. The following produces ``retrieved:
 <http://example.com>``:
 

--- a/specification.rst
+++ b/specification.rst
@@ -2248,9 +2248,7 @@ the output of the child elements).
 A delimiting element is any element as above which takes a ``delimiter`` 
 attribute, whether the attribute is supplied or not.
 
-The output of a delimiting element does not have delimiters from any ancestor
-delimiting element interspersed within it. The following produces ``retrieved:
-<http://example.com>``:
+Delimiters from any ancestor delimiting element are not applied within the output of a delimiting element. The following produces ``retrieved: <http://example.com>``:
 
 .. sourcecode:: xml
 

--- a/specification.rst
+++ b/specification.rst
@@ -2255,15 +2255,16 @@ attribute, whether the attribute is supplied or not.
 The output of all delimiting elements is delimiter-encapsulated: no 
 ``delimiter`` from a parent delimiting element will delimit between multiple 
 outputs of an inner delimiter-encapsulated element. The following produces
-``a; bc``:
+``retrieved: <http://example.com>``:
 
 .. sourcecode:: xml
 
-    <group delimiter="; ">
-      <text value="a" />
+    <group delimiter=": ">
+      <text term="retrieved" />
       <group>
-        <text value="b" />
-        <text value="c" />
+        <text value="&lt;" />
+        <text variable="URL"/>
+        <text value="&gt;" />
       </group>
     </group>
 

--- a/specification.rst
+++ b/specification.rst
@@ -1545,9 +1545,7 @@ control the testing logic, with allowed values:
 -  "none" - element only tests "true" when none of the conditions test "true"
    for any given test value
 
-The output of ``cs:choose`` (i.e. the output of the matching ``cs:if``,
-``cs:else-if``, or ``cs:else``) *does* have delimiters from the nearest
-ancestor delimiting element interspersed within it (see `delimiter`_).
+Delimiters from the nearest delimiters from the nearest ancestor delimiting element *are* applied within the output of ``cs:choose`` (i.e., the output of the matching ``cs:if``, ``cs:else-if``, or ``cs:else``; see `delimiter`_).
 
 Style Behavior
 --------------

--- a/specification.rst
+++ b/specification.rst
@@ -384,8 +384,8 @@ the item type is "book":
       </citation>
     </style>
 
-The output of a ``<text macro="...">`` is delimiter-encapsulated (see 
-`delimiter`_).
+The output of a ``<text macro="...">`` does not have delimiters from a parent 
+delimiting element interspersed within it (see `delimiter`_).
 
 Locale
 ^^^^^^
@@ -1547,11 +1547,8 @@ control the testing logic, with allowed values:
    for any given test value
 
 The output of ``cs:choose`` (i.e. the output of the matching ``cs:if``, 
-``cs:else-if``, or ``cs:else``) is *not* delimiter-encapsulated (see 
-`delimiter`_): if there are multiple elements output by the chosen branch, when 
-rendering a `delimiter`_ set on the nearest parent delimiting element, they are 
-considered to be separate pieces of output and delimiters are placed between 
-them.
+``cs:else-if``, or ``cs:else``) *does* have delimiters from a parent delimiting 
+element interspersed within it (see `delimiter`_).
 
 Style Behavior
 --------------
@@ -2252,9 +2249,9 @@ the output of the child elements).
 A delimiting element is any element as above which takes a ``delimiter`` 
 attribute, whether the attribute is supplied or not.
 
-The output of all delimiting elements is delimiter-encapsulated: no 
-``delimiter`` from a parent delimiting element will delimit between multiple 
-outputs of an inner delimiter-encapsulated element. The following produces
+The output of all delimiting elements is not subject to surrounding delimiters: 
+no ``delimiter`` from a parent delimiting element will delimit between multiple 
+outputs of an inner delimiting element. The following produces
 ``retrieved: <http://example.com>``:
 
 .. sourcecode:: xml

--- a/specification.rst
+++ b/specification.rst
@@ -384,6 +384,9 @@ the item type is "book":
       </citation>
     </style>
 
+The output of a ``<text macro="...">`` is delimiter-encapsulated (see 
+`delimiter`_).
+
 Locale
 ^^^^^^
 
@@ -1543,6 +1546,13 @@ control the testing logic, with allowed values:
 -  "none" - element only tests "true" when none of the conditions test "true"
    for any given test value
 
+The output of ``cs:choose`` (i.e. the output of the matching ``cs:if``, 
+``cs:else-if``, or ``cs:else``) is _not_ delimiter-encapsulated (see 
+`delimiter`_): if there are multiple elements output by the chosen branch, when 
+rendering a `delimiter`_ set on the nearest parent delimiting element, they are 
+considered to be separate pieces of output and delimiters are placed between 
+them.
+
 Style Behavior
 --------------
 
@@ -2238,6 +2248,24 @@ allowed when ``cs:date`` calls a localized date format), ``cs:names``
 (delimiting name lists from different `name variables`_), ``cs:name``
 (delimiting names within name lists), ``cs:group`` and ``cs:layout`` (delimiting
 the output of the child elements).
+
+A delimiting element is any element as above which takes a ``delimiter`` 
+attribute, whether the attribute is supplied or not.
+
+The output of all delimiting elements is delimiter-encapsulated: no 
+``delimiter`` from a parent delimiting element will delimit between multiple 
+outputs of an inner delimiter-encapsulated element. The following produces
+``a; bc``:
+
+.. sourcecode:: xml
+
+    <group delimiter="; ">
+      <text value="a" />
+      <group>
+        <text value="b" />
+        <text value="c" />
+      </group>
+    </group>
 
 Display
 ~~~~~~~


### PR DESCRIPTION
Fixes #65, Supersedes #116.

There are more words but I think it's easier to understand, especially with an example. It's also easier to extend it to other sequence-type elements as they arise.