### PR TITLE
Adjust role term list

### DIFF
--- a/specification.rst
+++ b/specification.rst
@@ -2522,20 +2522,8 @@ Quotation marks
 Roles
 ~~~~~
 
--  author
--  collection-editor
--  composer
--  container-author
--  director
--  editor
--  editorial-director
--  editortranslator
--  illustrator
--  interviewer
--  original-author
--  recipient
--  reviewed-author
--  translator
+For each name variable listed in Appendix IV, there is a corresponding term.
+Additionaly, there is a term "editortranslator" that is used when "editor" and "translator" are identical.
 
 Seasons
 ~~~~~~~

--- a/specification.rst
+++ b/specification.rst
@@ -2523,7 +2523,6 @@ Roles
 ~~~~~
 
 For each name variable listed in Appendix IV, there is a corresponding term.
-Additionaly, there is a term "editortranslator" that is used when "editor" and "translator" are identical.
 
 Seasons
 ~~~~~~~


### PR DESCRIPTION
I think the list of role terms should just make reference to the corresponding variable list. (As we do with types as well..) That should make updates a bit smoother.

~Question: Should the be a second sentence like: "Additionally, there's a editor-translator", or so? Or should we just add "editor-translator" to the list of variables? (Unsure which makes more sense...)~ (Edit: I^ve added `editor-translator` to the list of variables.)