### PR TITLE
Variable fixes

### DIFF
--- a/specification.rst
+++ b/specification.rst
@@ -3185,7 +3185,7 @@ reviewed-author
     Author of the item reviewed by the current item
 
 script-writer
-    Script-writer (e.g. of a movie)
+    Writer of a script or screenplay (e.g. of a film)
 
 series-creator
     Creator of a series (e.g. of a television series)

--- a/specification.rst
+++ b/specification.rst
@@ -3139,7 +3139,9 @@ editorial-director
     Managing editor ("Directeur de la Publication" in French)
 
 editor-translator
-    Editor and translator of a work. Must be automatically generated if editor and translator variables are identical
+    | Combined editor and translator of a work;
+    | The citation processory must be automatically generate if ``editor`` and ``translator`` variables are identical;
+    | May also be provided directly in item data
 
 executive-producer
     Executive producer (e.g. of a television series)

--- a/specification.rst
+++ b/specification.rst
@@ -2895,7 +2895,6 @@ ISBN
 ISSN
     International Standard Serial Number
 
-
 jurisdiction
     Geographic scope of relevance (e.g. "US" for a US patent; the court hearing
     a legal case)

--- a/specification.rst
+++ b/specification.rst
@@ -3054,7 +3054,7 @@ part-number
       journal article);
     | Use ``part-title`` for the title of the part, if any
 
-printing
+printing-number
     Printing number of the item or container holding the item
 
 section

--- a/specification.rst
+++ b/specification.rst
@@ -3138,6 +3138,9 @@ editor
 editorial-director
     Managing editor ("Directeur de la Publication" in French)
 
+editor-translator
+    Automatically constructed if editor and translator are identical
+
 executive-producer
     Executive producer (e.g. of a television series)
 

--- a/specification.rst
+++ b/specification.rst
@@ -3141,11 +3141,20 @@ editorial-director
 executive-producer
     Executive producer (e.g. of a television series)
 
+guest
+    Host
+
+host
+    Guest
+
 illustrator
     Illustrator (e.g. of a children's book or graphic novel)
 
 interviewer
     Interviewer (e.g. of an interview)
+
+narrator
+    Narrator
 
 organizer
     Organizer of an event (e.g. organizer of a workshop or conference)
@@ -3169,6 +3178,12 @@ recipient
 
 reviewed-author
     Author of the item reviewed by the current item
+
+script-writer
+    Script-writer (e.g. of a movie)
+
+series-creator
+    Creator of a series
 
 translator
     Translator

--- a/specification.rst
+++ b/specification.rst
@@ -3157,7 +3157,7 @@ interviewer
     Interviewer (e.g. of an interview)
 
 narrator
-    Narrator
+    Narrator (e.g. of an audio book)
 
 organizer
     Organizer of an event (e.g. organizer of a workshop or conference)

--- a/specification.rst
+++ b/specification.rst
@@ -2873,7 +2873,7 @@ DOI
     Digital Object Identifier (e.g. "10.1128/AEM.02591-07")
 
 event
-    Deprecated legacy variant of ``event-title``;
+    Deprecated legacy variant of ``event-title``
 
 event-title
     Name of the event related to the item (e.g. the conference name when citing

--- a/specification.rst
+++ b/specification.rst
@@ -3049,7 +3049,7 @@ page-first
     First page of the range of pages the item (e.g. a journal article) covers in
     a container (e.g. a journal issue)
 
-part
+part-number
     | Number of the specific part of the item being cited (e.g. part 2 of a 
       journal article);
     | Use ``part-title`` for the title of the part, if any

--- a/specification.rst
+++ b/specification.rst
@@ -2873,6 +2873,9 @@ DOI
     Digital Object Identifier (e.g. "10.1128/AEM.02591-07")
 
 event
+    Deprecated legacy variant of ``event-title``;
+
+event-title
     Name of the event related to the item (e.g. the conference name when citing
     a conference paper; the meeting where presentation was made)
 

--- a/specification.rst
+++ b/specification.rst
@@ -3148,7 +3148,7 @@ guest
     Guest (e.g. of a TV show or podcast)
 
 host
-    Guest
+    Host (e.g. of a TV show or podcast)
 
 illustrator
     Illustrator (e.g. of a children's book or graphic novel)

--- a/specification.rst
+++ b/specification.rst
@@ -3147,7 +3147,7 @@ executive-producer
     Executive producer (e.g. of a television series)
 
 guest
-    Guest (e.g. of a TV show or podcast)
+    Guest (e.g. on a TV show or podcast)
 
 host
     Host (e.g. of a TV show or podcast)

--- a/specification.rst
+++ b/specification.rst
@@ -3139,7 +3139,7 @@ editorial-director
     Managing editor ("Directeur de la Publication" in French)
 
 editor-translator
-    Automatically constructed if editor and translator are identical
+    Editor and translator of a work. Should be automatically generated if editor and translator variables are identical
 
 executive-producer
     Executive producer (e.g. of a television series)

--- a/specification.rst
+++ b/specification.rst
@@ -2886,26 +2886,12 @@ genre
     | Do not use for topical descriptions or categories (e.g. "adventure" for an 
       adventure movie)
 
-ISAN
-    International Standard Audiovisual Number
-
 ISBN
     International Standard Book Number (e.g. "978-3-8474-1017-1")
-
-ISCI
-    International Standard Collection Identifier
-
-ISMN
-    International Standard Music Number
-
-ISRC
-    International Standard Recording Code
 
 ISSN
     International Standard Serial Number
 
-ISWC
-    International Standard Musical Work Code
 
 jurisdiction
     Geographic scope of relevance (e.g. "US" for a US patent; the court hearing

--- a/specification.rst
+++ b/specification.rst
@@ -3139,7 +3139,7 @@ editorial-director
     Managing editor ("Directeur de la Publication" in French)
 
 editor-translator
-    Editor and translator of a work. Should be automatically generated if editor and translator variables are identical
+    Editor and translator of a work. Must be automatically generated if editor and translator variables are identical
 
 executive-producer
     Executive producer (e.g. of a television series)

--- a/specification.rst
+++ b/specification.rst
@@ -3145,7 +3145,7 @@ executive-producer
     Executive producer (e.g. of a television series)
 
 guest
-    Host
+    Guest (e.g. of a TV show or podcast)
 
 host
     Guest

--- a/specification.rst
+++ b/specification.rst
@@ -3061,7 +3061,7 @@ section
     Section of the item or container holding the item (e.g. "§2.0.1" for a law; 
     "politics" for a newspaper article)
 
-supplement
+supplement-number
     Supplement number of the item or container holding the item (e.g. for 
     secondary legal items that are regularly updated between editions)
 

--- a/specification.rst
+++ b/specification.rst
@@ -3111,12 +3111,12 @@ collection-editor
     Editor of the collection holding the item (e.g. the series editor for a
     book)
 
-composer
-    Composer (e.g. of a musical score)
-
 compiler
     Person compiling or selecting material for an item from the works of various 
     persons or bodies (e.g. for an anthology)
+
+composer
+    Composer (e.g. of a musical score)
 
 container-author
     Author of the container holding the item (e.g. the book author for a book

--- a/specification.rst
+++ b/specification.rst
@@ -3186,7 +3186,7 @@ script-writer
     Script-writer (e.g. of a movie)
 
 series-creator
-    Creator of a series
+    Creator of a series (e.g. of a television series)
 
 translator
     Translator


### PR DESCRIPTION
This makes the list of variables conform to the variable list in the schema. I'm not particularly happy with the descriptions of the new name variables, so if someone has better suggestions ...

Question:
Should `editor-translator` be in the variable list? => Yes, done.