### PR TITLE
Prepare v1.0.2 release

### DIFF
--- a/specification.rst
+++ b/specification.rst
@@ -1,9 +1,20 @@
 CSL 1.0.2 Specification
 =======================
 
-by `Rintze M. Zelle, PhD <https://twitter.com/rintzezelle>`_
+Principal Authors 
+`Rintze M. Zelle, PhD <https://twitter.com/rintzezelle>`_, 
+`Brenton M. Wiernik <https://twitter.com/bmwiernik>`_, 
+Frank G. Bennett, Jr., 
+Bruce D'Arcus,
+Denis Maier
 
-with contributions from Frank G. Bennett, Jr. and Bruce D'Arcus.
+with additional contributions from 
+Julien Gonzalez,
+Sebastian Karcher,
+Sylvester Kiel,
+Cormac Relf,
+Lars Willighagen,
+and other CSL contributors.
 
 | |CCBYSA|_
 | This work is licensed under a `Creative Commons Attribution-ShareAlike 4.0 International License`__.


### PR DESCRIPTION
@denismaier and I have checked the spec against the schema, and I think all of the new variables/types/terms and other behavior changes have been accounted for. I also re-checked through the 1.0.2 schema and fixed a few bugs there. I think we could release the spec at this point and then continue to make additional behavior clarifications in outstanding issues as needed. We could then make a formal announcement that CSL 1.0.2 is ready for production use.

There are 2 open PRs tagged 1.0.2. We can probably merge them this week before a release?

Two points to discuss:
1. Regarding versioning, @rmzelle suggested that we get a DOI for the specificiation from Zenodo. We can get a separate DOI for v1.0.1, v1.0.2, etc. These could then be automatically archived with revision numbers as we make additional clarifications in the spec.
2. Regarding contributorship listing, @rmzelle suggested something similar to https://www.w3.org/TR/MathML3/, listing the principal authors with additional contributors listed subsequently. Does that sound okay to everyone, and are folks okay with their listing? Are there other folks that should be named in either category? (A motivation for me asking this question is that I am preparing my tenure application package and need to know how to indicate my CSL contributions.)