### PR TITLE
et-al-min has to be greater than et-al-use-first

### DIFF
--- a/specification.rst
+++ b/specification.rst
@@ -1074,7 +1074,8 @@ within a name variable. ``cs:name`` may carry the following attributes:
     Use of these two attributes enables et-al abbreviation. If the number of
     names in a name variable matches or exceeds the number set on ``et-al-min``,
     the rendered name list is truncated after reaching the number of names set
-    on ``et-al-use-first``. The "et-al" (or "and others") term is appended to
+    on ``et-al-use-first`` (``et-al-min`` has to be greater than 
+    ``et-al-use-first``). The "et-al" (or "and others") term is appended to
     truncated name lists (see also `Et-al`_). By default, when a name list is
     truncated to a single name, the name and the "et-al" (or "and others") term
     are separated by a space (e.g. "Doe et al."). When a name list is truncated


### PR DESCRIPTION
Stumbling upon this twice in a PR today I couldn’t find this restraint neither in the schema (I wouldn’t know how to express it there) nor in the documentation.