### PR TITLE
Remove implicit anchors attached to titles/whole bibliography

### DIFF
--- a/specification.rst
+++ b/specification.rst
@@ -3207,13 +3207,4 @@ If the bibliography entry for an item renders any of the following identifiers, 
 
 If the identifier is rendered as a URI, include rendered URI components (e.g. "https://doi.org/") in the link anchor. Do not include any other affix text in the link anchor (e.g. "Available from: ", "doi: ", "PMID: ").
 
-If the bibliography entry for an item does not render any of the above identifiers, then set the anchor of the link as the item ``title``. If ``title`` is not rendered, then set the anchor of the link as the full bibliography entry for the item. Set the target of the link as one of the following, in order of priority:
-
-1. ``doi``: prepend with "https://doi.org/"
-2. ``pmcid``: prepend with "https://www.ncbi.nlm.nih.gov/pmc/articles/"
-3. ``pmid``: prepend with "https://www.ncbi.nlm.nih.gov/pubmed/"
-4. ``url``: output as is
-
-If the item data does not include any of the above identifiers, do not include a link.
-
 Citation processors should include an option flag for calling applications to disable bibliography linking behavior.


### PR DESCRIPTION
I propose removing the second half of 'Appendix IV: Links' in CSL 1.1, which provides for adding an anchor to the title of a bibliography entry if the `url` fields are not rendered at all, or if there is no title, to the entire bibliography entry.

See my comment here: https://github.com/citation-style-language/schema/issues/395#issuecomment-903613329

> Yeah. I think the "if no url rendered in bib entry, add the anchor to the title` fallback thing goes too far. In a nutshell, I don't think anyone wants titles to be blue/underlined but link styling is fine for all the others, and that is quite tricky to resolve at the CSL processor level. More broadly, departing from a convention where every URL is visible in textual form is a bad idea. Think accidental inclusion of incorrect links that someone writing a paper might not even notice have made it in. Think sci-hub.

<details>
<summary>Expanding on some of those points</summary>

This is what I mean by the link styling:

1. CSL processors don't control styling beyond `<i>italic</i>` really, they can only do more with markup
2. Currently consumers of processor output can safely just render it verbatim and not worry that it looks horribly wrong, because the only things that are links are links. HTML by default has blue and underlined. This is fine right now. Links being blue is actually great for many reasons, including in PDFs esp for digital reading.
3. Occasionally highlighting entire bibliographic references breaks this, now they need to remove all link styling.
4. Because of \#1, would need new markup (`class="unstyled-anchor"`...) if you want to keep blue/underline for some links. The spec doesn't really talk about markup yet and this would either become another implementation-defined output thing, or require a bunch of spec work. Worthwhile work, but still.

An afterthought from an implementor's perspective, not super important though:

5. It's actually a lot of work to implement as written. "If a URL field is not rendered" is a question that isn't fully resolved until after disambiguation. Even if you pretend it's resolved early, anything non-local like this is hard, simply because the piece of code rendering the title can't know if the URL will be rendered until later, so it requires adding anchors late in the processing. All of this becomes *really* twisted when you do split author-in-text citations with a custom in-text part including a title, rendered separately from the rest of the cite. Doesn't really seem worth it from where I stand.

</details>

Two more notes on Appendix IV:

6. On the wording of Appendix IV in general -- I see no reason why this should apply only to bibliography entries, and make no mention of inline/note citations. You want the overall auto-hyperlinking behaviour in both.

7. The spec should probably also say that `url` fields that are not valid URLs should not be given an anchor at all. One of the benefits of link styling is that validity == styling+clickability is great for proofing.